### PR TITLE
feat: build_request 기반 빌드 제어 및 아카이브 추가

### DIFF
--- a/Build_Server.py
+++ b/Build_Server.py
@@ -1,64 +1,114 @@
-from flask import Flask, request, jsonify
+from flask import Flask, jsonify
 import subprocess
 import os
+import threading
+import shutil
+from datetime import datetime
 from openai import OpenAI
 
 print("OPENAI_API_KEY_BUILDSERVER =", os.environ.get("OPENAI_API_KEY_BUILDSERVER"))
 app = Flask(__name__)
 client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY_BUILDSERVER"))
 
+# 동시에 하나의 빌드만 처리하도록 Lock 사용
+build_lock = threading.Lock()
+
+
+def parse_build_request(path):
+    """build_request.txt 파일을 파싱하여 키-값 딕셔너리로 반환"""
+    info = {}
+    if not os.path.exists(path):
+        return info
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or ":" not in line:
+                continue
+            k, v = line.split(":", 1)
+            info[k.strip()] = v.strip()
+    return info
+
+
 @app.route("/ue_build", methods=["POST"])
 def build():
-    data = request.json
-    project_path = data.get("project_path")
-    project_name = data.get("project_name")
-    branch_name = data.get("branch_name")  # 브랜치명 추가
+    # 다른 빌드가 진행 중이면 "busy" 응답
+    if not build_lock.acquire(blocking=False):
+        return jsonify({"status": "busy"}), 429
 
-    if not project_path or not project_name or not branch_name:
-        return jsonify({"error": "Missing project_path, project_name, or branch_name"}), 400
+    try:
+        request_path = os.path.join(os.path.dirname(__file__), "build_request.txt")
+        info = parse_build_request(request_path)
 
-    # Git 브랜치 전환
-    subprocess.run(f'git -C "{project_path}" fetch origin {branch_name}', shell=True)
-    subprocess.run(f'git -C "{project_path}" checkout {branch_name}', shell=True)
-    subprocess.run(f'git -C "{project_path}" pull origin {branch_name}', shell=True)
+        project_path = info.get("project_path")
+        project_name = info.get("project_name")
+        branch_name = info.get("branch_name")
+        should_build = info.get("should_build", "false").lower() not in ("false", "0", "no")
+        # codex_fix.txt 등의 존재 여부와 무관하게 should_build 플래그로 빌드를 제어
 
-    # 빌드 실행
-    build_cmd = f'ue_build.bat "{project_path}" "{project_name}" "{branch_name}"'
-    result = subprocess.run(build_cmd, shell=True)
+        if not should_build:
+            return jsonify({"status": "no build requested"}), 200
 
-    if result.returncode != 0:
-        # 빌드 실패 시 Codex 호출
-        log_path = os.path.join(project_path, "build.log")
-        with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
-            build_log = f.read()
+        if not project_path or not project_name or not branch_name:
+            return jsonify({"error": "Missing project_path, project_name, or branch_name"}), 400
 
-        prompt = f"""
-        Build failed for Unreal project {project_name}.
-        Build log:
-        {build_log}
+        # Git 브랜치 전환
+        subprocess.run(f'git -C "{project_path}" fetch origin {branch_name}', shell=True)
+        subprocess.run(f'git -C "{project_path}" checkout {branch_name}', shell=True)
+        subprocess.run(f'git -C "{project_path}" pull origin {branch_name}', shell=True)
 
-        Please fix the code so the build passes.
-        """
+        # 빌드 실행
+        build_cmd = f'ue_build.bat "{project_path}" "{project_name}" "{branch_name}"'
+        result = subprocess.run(build_cmd, shell=True)
 
-        response = client.chat.completions.create(
-            model="gpt-4.1-nano",
-            messages=[
-                {"role": "system", "content": "You are an expert Unreal Engine C++ developer."},
-                {"role": "user", "content": prompt}
-            ]
-        )
+        if result.returncode != 0:
+            # 빌드 실패 시 Codex 호출
+            log_path = os.path.join(project_path, "build.log")
+            with open(log_path, "r", encoding="utf-8", errors="ignore") as f:
+                build_log = f.read()
 
-        fix_code = response.choices[0].message.content
-        fix_file_path = os.path.join(project_path, "codex_fix.txt")
-        with open(fix_file_path, "w", encoding="utf-8") as f:
-            f.write(fix_code)
+            prompt = f"""
+Build failed for Unreal project {project_name}.
+Build log:
+{build_log}
 
-        return jsonify({
-            "status": "build failed",
-            "fix_suggestion": fix_file_path
-        }), 200
+Please fix the code so the build passes.
+"""
 
-    return jsonify({"status": "build succeeded"}), 200
+            response = client.chat.completions.create(
+                model="gpt-4.1-nano",
+                messages=[
+                    {"role": "system", "content": "You are an expert Unreal Engine C++ developer."},
+                    {"role": "user", "content": prompt}
+                ]
+            )
+
+            fix_code = response.choices[0].message.content
+            fix_file_path = os.path.join(project_path, "codex_fix.txt")
+            with open(fix_file_path, "w", encoding="utf-8") as f:
+                f.write(fix_code)
+
+            resp = {
+                "status": "build failed",
+                "fix_suggestion": fix_file_path
+            }
+        else:
+            resp = {"status": "build succeeded"}
+
+        # 빌드 요청 파일을 아카이브 폴더에 복사
+        archive_dir = os.path.join(project_path, "build_request_archive")
+        os.makedirs(archive_dir, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        shutil.copy2(request_path, os.path.join(archive_dir, f"build_request_{timestamp}.txt"))
+
+        # 플래그 초기화 (should_build:false)
+        info["should_build"] = "false"
+        with open(request_path, "w", encoding="utf-8") as f:
+            for k, v in info.items():
+                f.write(f"{k}:{v}\n")
+
+        return jsonify(resp), 200
+    finally:
+        build_lock.release()
 
 
 if __name__ == "__main__":
@@ -67,3 +117,4 @@ if __name__ == "__main__":
     except Exception as e:
         print("서버 실행 중 에러:", e)
         input("엔터를 누르세요")
+

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ export OPENAI_API_KEY_BUILDSERVER=sk-xxxxxxxxxxxxxxxxxxxxxx
 빌드 서버에 전달하는 `build_request.txt` 파일은 다음과 같이 작성합니다.
 
 ```txt
-project_path: D:\Projects\MyUnrealProject
+project_path: C:\WorkSpace\UAIAgent
 project_name: MyUnrealProject
 branch_name: feature/login-api
 should_build: true

--- a/README.md
+++ b/README.md
@@ -56,28 +56,23 @@ export OPENAI_API_KEY_BUILDSERVER=sk-xxxxxxxxxxxxxxxxxxxxxx
 project_path: D:\Projects\MyUnrealProject
 project_name: MyUnrealProject
 branch_name: feature/login-api
+should_build: true
 # (필요 시 추가 정보: commit, options 등)
 ```
 
-- 각 값은 POST /ue_build API 호출 시 json 파라미터와 동일하게 사용됨
-- (예시: GitHub Action 등에서 자동으로 생성해 전송)
+- `should_build`를 `true`(또는 `1`)로 설정하면 빌드가 실행되며, 빌드 후에는 자동으로 `false`로 되돌아갑니다.
+- 서버는 빌드 실행 시 현재 파일을 `<project_path>/build_request_archive/` 폴더에 타임스탬프 이름으로 복사해 보관합니다.
+- 각 값은 향후 다른 도구가 파일을 수정하여 빌드를 유발할 수 있도록 단순한 `key:value` 형식으로 유지합니다.
+- 분기명을 변경하거나 추후 `commit` 등의 추가 파라미터를 넣어 빌드 조건을 제어할 수 있습니다.
 
 ---
 
 ## API 요청 예시
 
-빌드 서버에 빌드를 요청할 때  
-아래와 같이 POST로 요청합니다.
+`build_request.txt` 내용을 수정한 뒤 빌드를 시작하려면 아래와 같이 POST 요청만 보내면 됩니다. 요청 본문은 비워도 됩니다.
 
 ```
 POST http://<빌드서버주소>:9000/ue_build
-Content-Type: application/json
-
-{
-  "project_path": "D:\Projects\MyUnrealProject",
-  "project_name": "MyUnrealProject",
-  "branch_name": "feature/login-api"
-}
 ```
 
 **응답 예시**

--- a/build_request.txt
+++ b/build_request.txt
@@ -1,0 +1,5 @@
+project_path:
+project_name:
+branch_name:
+should_build:false
+# commit:


### PR DESCRIPTION
## Summary
- `build_request.txt` 내용을 읽어 빌드 여부를 결정하고 아카이빙
- 동시에 하나의 빌드만 처리하며, 실행 후 플래그 초기화
- README에 `build_request.txt` 작성 요령과 요청 방식 갱신

## Testing
- `python -m py_compile Build_Server.py`
- `git push` *(failed: No configured push destination)*

------
https://chatgpt.com/codex/tasks/task_e_689308b3b28883308aac6158ef3b80d9